### PR TITLE
Add Meteor.settings.validatorStatus0

### DIFF
--- a/default_settings.json
+++ b/default_settings.json
@@ -6,6 +6,7 @@
         "slashingWindow": 10000,
         "uptimeWindow": 250,
         "initialPageSize": 30,
+        "validatorStatus0": 0,
         "bech32PrefixAccAddr": "cosmos",
         "bech32PrefixAccPub": "cosmospub",
         "bech32PrefixValAddr": "cosmosvaloper",

--- a/imports/api/blocks/server/methods.js
+++ b/imports/api/blocks/server/methods.js
@@ -375,7 +375,10 @@ Meteor.methods({
                                             validator.profile_url =  getValidatorProfileUrl(validatorData.description.identity)
                                         validator.operator_address = validatorData.operator_address;
                                         validator.delegator_address = Meteor.call('getDelegator', validatorData.operator_address);
-                                        validator.jailed = validatorData.jailed;
+                                        
+                                        // validatorData.jailed may be undefined in cosmos-sdk v0.39.0.
+                                        validator.jailed = !!validatorData.jailed;
+
                                         validator.status = validatorData.status;
                                         validator.min_self_delegation = validatorData.min_self_delegation;
                                         validator.tokens = validatorData.tokens;
@@ -521,7 +524,7 @@ Meteor.methods({
                                 Object.keys(validatorSet).forEach((conPubKey) => {
                                     let validatorData = validatorSet[conPubKey];
                                     // Active validators should have been updated in previous steps
-                                    if (validatorData.status === 2)
+                                    if (validatorData.status === 2 + Meteor.settings.public.validatorStatus0)
                                         return
 
                                     if (dbValidators[conPubKey] == undefined) {
@@ -621,7 +624,7 @@ Meteor.methods({
 
                         if (height % 60 == 1){
                             console.log("===== calculate voting power distribution =====");
-                            let activeValidators = Validators.find({status:2,jailed:false},{sort:{voting_power:-1}}).fetch();
+                            let activeValidators = Validators.find({status:2 + Meteor.settings.public.validatorStatus0,jailed:false},{sort:{voting_power:-1}}).fetch();
                             let numTopTwenty = Math.ceil(activeValidators.length*0.2);
                             let numBottomEighty = activeValidators.length - numTopTwenty;
 

--- a/imports/api/chain/server/methods.js
+++ b/imports/api/chain/server/methods.js
@@ -239,7 +239,7 @@ Meteor.methods({
                                 delegator_address: msg[m].value.delegator_address,
                                 voting_power: Math.floor(parseInt(msg[m].value.value.amount) / Coin.StakingCoin.fraction),
                                 jailed: false,
-                                status: 2
+                                status: 2 + Meteor.settings.validatorStatus0
                             }
 
                             totalVotingPower += validator.voting_power;

--- a/imports/api/validators/server/publications.js
+++ b/imports/api/validators/server/publications.js
@@ -25,7 +25,7 @@ publishComposite('validators.firstSeen',{
 
 Meteor.publish('validators.voting_power', function(){
     return Validators.find({
-        status: 2,
+        status: 2 + Meteor.settings.public.validatorStatus0,
         jailed:false
     },{
         sort:{

--- a/imports/ui/components/AccountTooltip.jsx
+++ b/imports/ui/components/AccountTooltip.jsx
@@ -49,7 +49,7 @@ export default class AccountTooltip extends Account{
             return
         let validator = this.state.validator;
         let moniker = validator.description && validator.description.moniker || validator.address;
-        let isActive = validator.status == 2 && !validator.jailed;
+        let isActive = validator.status == 2 + Meteor.settings.public.validatorStatus0 && !validator.jailed;
 
         return <UncontrolledPopover className='validator-popover' trigger="hover" placement="right" target={this.ref}>
             <Card className='validator-popover-card' body outline color="danger">
@@ -77,7 +77,7 @@ export default class AccountTooltip extends Account{
             (validator.unbonding_time?<TimeStamp time={validator.unbonding_time}/>:null)}
          </CardText>:null}
         {(!isActive)?<CardText className="bond-status data" xs={2}>
-        <Col xs={6}>{(validator.status == 0)?<Badge color="secondary">Unbonded</Badge>:<Badge color="warning">Unbonding</Badge>}</Col>
+        <Col xs={6}>{(validator.status == Meteor.settings.public.validatorStatus0)?<Badge color="secondary">Unbonded</Badge>:<Badge color="warning">Unbonding</Badge>}</Col>
         <Col xs={6}>{validator.jailed?<Badge color="danger">Jailed</Badge>:''}</Col>
          </CardText>:null}
         {(isActive)?<CardText className="uptime data">

--- a/imports/ui/home/TopValidatorsContainer.js
+++ b/imports/ui/home/TopValidatorsContainer.js
@@ -21,7 +21,7 @@ export default TopValidatorsContainer = withTracker(() => {
     
     if (Meteor.isServer || !loading){
         status = Chain.findOne({chainId:Meteor.settings.public.chainId});
-        validators = Validators.find({status: 2, jailed:false}).fetch();
+        validators = Validators.find({status: 2 + Meteor.settings.public.validatorStatus0, jailed:false}).fetch();
 
         if (Meteor.isServer){
             // loading = false;

--- a/imports/ui/ledger/LedgerActions.jsx
+++ b/imports/ui/ledger/LedgerActions.jsx
@@ -119,7 +119,7 @@ return <span><CoinAmount mint className='gas' amount={props.gas * Meteor.setting
 }
 
 const isActiveValidator = (validator) => {
-    return !validator.jailed && validator.status == 2;
+    return !validator.jailed && validator.status == 2 + Meteor.settings.public.validatorStatus0;
 }
 
 const isBetween = (value, min, max) => {
@@ -511,7 +511,7 @@ class LedgerButton extends Component {
 
     getValidatorOptions = () => {
         let activeValidators = Validators.find(
-            {"jailed": false, "status": 2},
+            {"jailed": false, "status": 2 + Meteor.settings.public.validatorStatus0},
             {"sort":{"description.moniker":1}}
         );
         let redelegations = this.state.redelegations || {};

--- a/imports/ui/validators/List.jsx
+++ b/imports/ui/validators/List.jsx
@@ -19,7 +19,7 @@ const ValidatorRow = (props) => {
             {(!props.inactive)?<Col className="commission data" xs={{size:4}} md={{size:1,offset:0}} lg={2}><i className="material-icons d-sm-none">call_split</i> <span>{props.validator.commission.commission_rates?numbro(props.validator.commission.commission_rates.rate).format('0.00%'):''}</span></Col>:''}
             {(!props.inactive)?<Col className="uptime data" xs={{size:2,order:"last"}} md={2}><Progress animated value={props.validator.uptime}><span className="d-none d-md-inline">{props.validator.uptime?props.validator.uptime.toFixed(2):0}%</span><span className="d-md-none">&nbsp;</span></Progress></Col>:''}
             {(props.inactive)?<Col className="last-seen data" xs={{size:10,offset:2}}md={{size:3, offset:0}}>{props.validator.lastSeen?<TimeStamp time={props.validator.lastSeen}/>:''}</Col>:''}
-            {(props.inactive)?<Col className="bond-status data" xs={2} md={1}>{(props.validator.status == 0)?<Badge color="secondary"><span>U<span className="d-none d-md-inline">nbonded</span></span></Badge>:<Badge color="warning"><span>U<span className="d-none d-md-inline">nbonding</span></span></Badge>}</Col>:''}
+            {(props.inactive)?<Col className="bond-status data" xs={2} md={1}>{(props.validator.status == Meteor.settings.public.validatorStatus0)?<Badge color="secondary"><span>U<span className="d-none d-md-inline">nbonded</span></span></Badge>:<Badge color="warning"><span>U<span className="d-none d-md-inline">nbonding</span></span></Badge>}</Col>:''}
             {(props.inactive)?<Col className="jail-status data" xs={2} md={1}>{props.validator.jailed?<Badge color="danger"><span>J<span className="d-none d-md-inline">ailed</span></span></Badge>:''}</Col>:''}
         </Row></SentryBoundary>
     </Card>

--- a/imports/ui/validators/ListContainer.js
+++ b/imports/ui/validators/ListContainer.js
@@ -19,7 +19,7 @@ export default ValidatorListContainer = withTracker((props) => {
     if (props.inactive){
         validatorsCond = {
             $or: [
-                { status: { $lt : 3 } },
+                { status: { $lt : 2 + Meteor.settings.public.validatorStatus0 } },
                 { jailed: true }
             ]
         }
@@ -27,7 +27,7 @@ export default ValidatorListContainer = withTracker((props) => {
     else{
         validatorsCond = {
             jailed: false,
-            status: 3
+            status: 2 + Meteor.settings.public.validatorStatus0
         }
     }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
<!-- Small description. What have you fixed or changed? -->
Hi @kwunyeung,

This PR adds a generic `Meteor.settings.validatorStatus0` configuration, whose `default_settings.json` value is 0.  That means validator status is 0, 1, or 2.

For IBC-alpha, I'm setting this value to 1, so that validator status is 1, 2, 3.

Also, I noticed that `validatorData.jailed` is`undefined` on the ibc-alpha branch.  I've hacked around this in this PR.

Fixes #311

## Checklist
- [X] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Added an entry to the `CHANGELOG.md` file.
- [X] Re-reviewed `Files changed` in the Github PR explorer.

