### PR TITLE
feat: add Agoric-specific Eventual Send transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed an issue on displaying individual transaction.
 * Updated Ledger app name checking so that it will follows the value defined in settings.
 * [#213] Updated `@ledgerhq/hw-transport-webusb` pkg to v5.49.0 to fix Ledger errors on Windows10
+* [#492] Display Agoric's MsgDeliverInbound and MsgProvision transactions
 
 ## v0.41.x-7 (Stargate compatible)
 

--- a/both/i18n/en-us.i18n.yml
+++ b/both/i18n/en-us.i18n.yml
@@ -219,7 +219,7 @@ activities:
     from: 'from'
     messages: 'message(s)'
     acknowledgement: 'acknowledgement'
-    via: 'via'
+    withPowerFlags: 'with power flags'
     operatingAt: 'operating at'
     withMoniker: 'with moniker'
     withTitle: 'with title'
@@ -243,3 +243,4 @@ messageTypes:
     IBCTransfer: 'IBC Transfer'
     IBCReceive: 'IBC Receive'
     AgoricSend: 'Eventual Send'
+    AgoricProvision: 'Provision Client'

--- a/both/i18n/en-us.i18n.yml
+++ b/both/i18n/en-us.i18n.yml
@@ -145,6 +145,7 @@ transactions:
     distribution: 'Distribution'
     governance: 'Governance'
     slashing: 'Slashing'
+    IBC: 'IBC'
 proposals:
     notFound: 'No proposal found.'
     listOfProposals: 'Here is a list of governance proposals.'
@@ -216,6 +217,9 @@ activities:
     failedTo: 'failed to '
     to: 'to'
     from: 'from'
+    messages: 'message(s)'
+    acknowledgement: 'acknowledgement'
+    via: 'via'
     operatingAt: 'operating at'
     withMoniker: 'with moniker'
     withTitle: 'with title'
@@ -238,3 +242,4 @@ messageTypes:
     unjail: 'Unjail'
     IBCTransfer: 'IBC Transfer'
     IBCReceive: 'IBC Receive'
+    AgoricSend: 'Eventual Send'

--- a/imports/ui/blocks/Block.jsx
+++ b/imports/ui/blocks/Block.jsx
@@ -20,6 +20,7 @@ export default class Block extends Component{
             distributionTxs: {},
             governanceTxs: {},
             slashingTxs: {},
+            IBCTxs: {},
         };
     }
 
@@ -32,7 +33,8 @@ export default class Block extends Component{
                     stakingTxs: this.props.stakingTxs,
                     distributionTxs: this.props.distributionTxs,
                     governanceTxs: this.props.governanceTxs,
-                    slashingTxs: this.props.slashingTxs
+                    slashingTxs: this.props.slashingTxs,
+                    IBCTxs: this.props.IBCTxs,
                 })
             }
         }
@@ -79,6 +81,7 @@ export default class Block extends Component{
                         distributionTxs={this.state.distributionTxs}
                         governanceTxs={this.state.governanceTxs}
                         slashingTxs={this.state.slashingTxs}
+                        IBCTxs={this.state.IBCTxs}
                     />
                 </Container>
             }

--- a/imports/ui/blocks/BlockContainer.js
+++ b/imports/ui/blocks/BlockContainer.js
@@ -74,7 +74,9 @@ export default BlockContainer = withTracker((props) => {
         IBCTxs: transactionsExist ? Transactions.find({
             $or: [
                 {"tx.body.messages.@type":"/cosmos.IBCTransferMsg"},
-                {"tx.body.messages.@type":"/cosmos.IBCReceiveMsg"}
+                {"tx.body.messages.@type":"/cosmos.IBCReceiveMsg"},
+                // TODO: Later should be dynamic IBC.
+                {"tx.body.messages.@type":"/agoric.swingset.MsgDeliverInbound"},
             ]
         }).fetch() : {},
     };

--- a/imports/ui/components/Activities.jsx
+++ b/imports/ui/components/Activities.jsx
@@ -94,7 +94,10 @@ export default class Activites extends Component {
             return <MsgType type={msg["@type"]} />
         case "/cosmos.IBCReceiveMsg":
             return <MsgType type={msg["@type"]} />
-
+        case "/agoric.swingset.MsgDeliverInbound":
+            const nmsgs = msg.messages ? msg.messages.length : 0;
+            return <p><Account address={msg.submitter} /> {(this.props.invalid)?<T>activities.failedTo</T>:''}<MsgType type={msg["@type"]} /> <em className="text-success">{nmsgs ? <>{nmsgs} <T>activities.messages</T></> : <T>activities.acknowledgement</T>}</em><T>common.fullStop</T></p>
+ 
         default:
             return <div><ReactJson src={msg} /></div>
         }

--- a/imports/ui/components/Activities.jsx
+++ b/imports/ui/components/Activities.jsx
@@ -97,6 +97,9 @@ export default class Activites extends Component {
         case "/agoric.swingset.MsgDeliverInbound":
             const nmsgs = msg.messages ? msg.messages.length : 0;
             return <p><Account address={msg.submitter} /> {(this.props.invalid)?<T>activities.failedTo</T>:''}<MsgType type={msg["@type"]} /> <em className="text-success">{nmsgs ? <>{nmsgs} <T>activities.messages</T></> : <T>activities.acknowledgement</T>}</em><T>common.fullStop</T></p>
+        case "/agoric.swingset.MsgProvision":
+            const powers = msg.power_flags.length > 0 ? <><T>activities.withPowerFlags</T> <em className="text-success">{msg.power_flags.join(',')}</em> </> : '';
+            return <p><Account address={msg.submitter} /> {(this.props.invalid)?<T>activities.failedTo</T>:''}<MsgType type={msg["@type"]} /> <span className="address"><Account address={msg.address}/></span>{powers}<T>common.fullStop</T></p>
  
         default:
             return <div><ReactJson src={msg} /></div>

--- a/imports/ui/components/MsgType.jsx
+++ b/imports/ui/components/MsgType.jsx
@@ -49,6 +49,8 @@ export const MsgType = (props) => {
         return <Badge color="dark"><T>messageTypes.IBCTransfer</T></Badge>;
     case "/cosmos.IBCReceiveMsg":
         return <Badge color="dark"><T>messageTypes.IBCReceive</T></Badge>;
+    case "/agoric.swingset.MsgDeliverInbound":
+        return <Badge color="success"><T>messageTypes.AgoricSend</T></Badge>
 
     default:
         return <Badge color="primary">{props.type}</Badge>;

--- a/imports/ui/components/MsgType.jsx
+++ b/imports/ui/components/MsgType.jsx
@@ -51,6 +51,8 @@ export const MsgType = (props) => {
         return <Badge color="dark"><T>messageTypes.IBCReceive</T></Badge>;
     case "/agoric.swingset.MsgDeliverInbound":
         return <Badge color="success"><T>messageTypes.AgoricSend</T></Badge>
+    case "/agoric.swingset.MsgProvision":
+        return <Badge color="success"><T>messageTypes.AgoricProvision</T></Badge>
 
     default:
         return <Badge color="primary">{props.type}</Badge>;

--- a/imports/ui/components/Transactions.jsx
+++ b/imports/ui/components/Transactions.jsx
@@ -14,6 +14,7 @@ export default class ValidatorTransactions extends Component{
             distributionTxs: {},
             governanceTxs: {},
             slashingTxs: {},
+            IBCTxs: {},
         };  
     }
 
@@ -26,7 +27,8 @@ export default class ValidatorTransactions extends Component{
                     stakingTxs: this.props.stakingTxs,
                     distributionTxs: this.props.distributionTxs,
                     governanceTxs: this.props.governanceTxs,
-                    slashingTxs: this.props.slashingTxs
+                    slashingTxs: this.props.slashingTxs,
+                    IBCTxs: this.props.IBCTxs,
                 })
             }
         }
@@ -43,6 +45,7 @@ export default class ValidatorTransactions extends Component{
                 distributionTxs={this.state.distributionTxs}
                 governanceTxs={this.state.governanceTxs}
                 slashingTxs={this.state.slashingTxs}
+                IBCTxs={this.state.IBCTxs}
             />
         }
         else {

--- a/imports/ui/components/TransactionsContainer.js
+++ b/imports/ui/components/TransactionsContainer.js
@@ -64,7 +64,8 @@ export default TransactionsContainer = withTracker((props) => {
         IBCTxs: transactionsExist ? Transactions.find({
             $or: [
                 {"tx.body.messages.@type":"/cosmos.IBCTransferMsg"},
-                {"tx.body.messages.@type":"/cosmos.IBCReceiveMsg"}
+                {"tx.body.messages.@type":"/cosmos.IBCReceiveMsg"},
+                {"tx.body.messages.@type":"/agoric.swingset.MsgDeliverInbound"},
             ]
         }).fetch() : {}
     };

--- a/imports/ui/transactions/TransactionTabs.jsx
+++ b/imports/ui/transactions/TransactionTabs.jsx
@@ -16,7 +16,8 @@ export default class TransactionTabs extends Component{
             stakingTxs: {},
             distributionTxs: {},
             governanceTxs: {},
-            slashingTxs: {}
+            slashingTxs: {},
+            IBCTxs: {},
         }
     }
 
@@ -35,7 +36,8 @@ export default class TransactionTabs extends Component{
                 stakingTxs: this.props.stakingTxs,
                 distributionTxs: this.props.distributionTxs,
                 governanceTxs: this.props.governanceTxs,
-                slashingTxs: this.props.slashingTxs
+                slashingTxs: this.props.slashingTxs,
+                IBCTxs: this.props.IBCTxs,
             })    
         }
     }
@@ -83,6 +85,14 @@ export default class TransactionTabs extends Component{
                             onClick={() => { this.toggle('tx-slashing'); }}
                         >
                             <T>transactions.slashing</T> ({numbro(this.state.slashingTxs.length).format("0,0")})
+                        </NavLink>
+                    </NavItem>
+                    <NavItem>
+                        <NavLink
+                            className={classnames({ active: this.state.activeTab === 'tx-IBC' })}
+                            onClick={() => { this.toggle('tx-IBC'); }}
+                        >
+                            <T>transactions.IBC</T> ({numbro(this.state.IBCTxs.length).format("0,0")})
                         </NavLink>
                     </NavItem>
                 </Nav>
@@ -147,6 +157,20 @@ export default class TransactionTabs extends Component{
                         <Row>
                             <Col>
                                 {(this.state.slashingTxs.length > 0)?this.state.slashingTxs.map((tx, i) => {
+                                    return <TransactionRow 
+                                        key={i} 
+                                        index={i} 
+                                        tx={tx} 
+                                        blockList
+                                    />
+                                }):''}
+                            </Col>
+                        </Row>
+                    </TabPane>
+                    <TabPane tabId="tx-IBC">
+                        <Row>
+                            <Col>
+                                {(this.state.IBCTxs.length > 0)?this.state.IBCTxs.map((tx, i) => {
                                     return <TransactionRow 
                                         key={i} 
                                         index={i} 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Added the Agoric-specific `/agoric.swingset.MsgDeliverInbound` "Eventual Send" transaction type support.

This is a simple transaction that predates IBC.  Here is how it displays:

![Screen Shot 2021-03-15 at 9 09 14 PM](https://user-images.githubusercontent.com/457244/111250294-b6b6ed00-85d2-11eb-8187-3c8336e676a6.png)

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Run `meteor npm run lint`
- [x] Added an entry to the `CHANGELOG.md` file.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
